### PR TITLE
Defines setup file to be sourced after installation

### DIFF
--- a/setup.R
+++ b/setup.R
@@ -1,0 +1,14 @@
+## Setup - source after installation to setup necessary output files and directories
+
+#create output folder directory if it doesn't exist
+if(!dir.exists("ProteoVista_output")) {
+    message("Initiallizing ProteoVista Output Subfolder...")
+    dir.create("./ProteoVista_output")
+}
+
+#install any missing packages based on renv dependencies in renv.lock file
+if (requireNamespace("renv", quietly = TRUE)) {
+    renv::restore(prompt = FALSE)
+} else {
+    message("Package 'renv' is not installed. Please run install.packages('renv') and then re-run source(setup.R)"
+}


### PR DESCRIPTION
This pull request introduces a new `setup.R` script to streamline the initialization process for the project. The script ensures necessary output directories are created and installs missing dependencies using `renv`.

Key changes:

**Setup script for initialization:**
* Added a check to create the `ProteoVista_output` directory if it does not already exist, ensuring proper organization of output files.
* Integrated `renv::restore` to automatically install missing packages based on the `renv.lock` file, simplifying dependency management. Includes a fallback message if the `renv` package is not installed.